### PR TITLE
Use unsigned long for representing times.

### DIFF
--- a/Thread.cpp
+++ b/Thread.cpp
@@ -1,6 +1,6 @@
 #include "Thread.h"
 
-Thread::Thread(void (*callback)(void), long _interval){
+Thread::Thread(void (*callback)(void), unsigned long _interval){
 	enabled = true;
 	onRun(callback);
 	_cached_next_run = 0;
@@ -15,11 +15,7 @@ Thread::Thread(void (*callback)(void), long _interval){
 	setInterval(_interval);
 };
 
-void Thread::runned(long time){
-	// If less than 0, than get current ticks
-	if(time < 0)
-		time = millis();
-
+void Thread::runned(unsigned long time){
 	// Saves last_run
 	last_run = time;
 
@@ -27,21 +23,20 @@ void Thread::runned(long time){
 	_cached_next_run = last_run + interval;
 }
 
-void Thread::setInterval(long _interval){
-	// Filter intervals less than 0
-	interval = (_interval < 0? 0: _interval);
+void Thread::setInterval(unsigned long _interval){
+	// Save interval
+	interval = _interval;
 
 	// Cache the next run based on the last_run
 	_cached_next_run = last_run + interval;
 }
 
-bool Thread::shouldRun(long time){
-	// If less than 0, than get current ticks
-	if(time < 0)
-		time = millis();
+bool Thread::shouldRun(unsigned long time){
+	// If the "sign" bit is set the signed difference would be negative
+	bool time_remaining = (time - _cached_next_run) & 0x80000000;
 
 	// Exceeded the time limit, AND is enabled? Then should run...
-	return ((time >= _cached_next_run) && enabled);
+	return !time_remaining && enabled;
 }
 
 void Thread::onRun(void (*callback)(void)){

--- a/Thread.h
+++ b/Thread.h
@@ -33,13 +33,13 @@
 class Thread{
 protected:
 	// Desired interval between runs
-	long interval;
+	unsigned long interval;
 
 	// Last runned time in Ms
-	long last_run;
+	unsigned long last_run;
 
 	// Scheduled run in Ms (MUST BE CACHED)	
-	long _cached_next_run;
+	unsigned long _cached_next_run;
 
 	/*
 		IMPORTANT! Run after all calls to run()
@@ -47,7 +47,10 @@ protected:
 		NOTE: This MUST be called if extending
 		this class and implementing run() method
 	*/
-	void runned(long time=-1);	
+	void runned(unsigned long time);
+
+	// Default is to mark it runned "now"
+	void runned() { runned(millis()); }
 
 	// Callback for run() if not implemented
 	void (*_onRun)(void);		
@@ -65,13 +68,16 @@ public:
 		String ThreadName;			
 	#endif
 
-	Thread(void (*callback)(void) = NULL, long _interval = 0);
+	Thread(void (*callback)(void) = NULL, unsigned long _interval = 0);
 
 	// Set the desired interval for calls, and update _cached_next_run
-	virtual void setInterval(long _interval);
+	virtual void setInterval(unsigned long _interval);
 
 	// Return if the Thread should be runned or not
-	virtual bool shouldRun(long time = -1);
+	virtual bool shouldRun(unsigned long time);
+
+	// Default is to check whether it should run "now"
+	bool shouldRun() { return shouldRun(millis()); }
 
 	// Callback set
 	void onRun(void (*callback)(void));

--- a/ThreadController.cpp
+++ b/ThreadController.cpp
@@ -1,7 +1,7 @@
 #include "Thread.h"
 #include "ThreadController.h"
 
-ThreadController::ThreadController(long _interval): Thread(){
+ThreadController::ThreadController(unsigned long _interval): Thread(){
 	cached_size = 0;
 
 	clear();
@@ -22,7 +22,7 @@ void ThreadController::run(){
 	if(_onRun != NULL)
 		_onRun();
 
-	long time = millis();
+	unsigned long time = millis();
 	int checks = 0;
 	for(int i = 0; i < MAX_THREADS && checks <= cached_size; i++){
 		// Object exists? Is enabled? Timeout exceeded?

--- a/ThreadController.h
+++ b/ThreadController.h
@@ -26,7 +26,7 @@ protected:
 	Thread* thread[MAX_THREADS];
 	int cached_size;
 public:
-	ThreadController(long _interval = 0);
+	ThreadController(unsigned long _interval = 0);
 
 	// run() Method is overrided
 	void run();


### PR DESCRIPTION
All the time calculations made on signed longs were wrong after 2^31 ms
~ 24.9 days. This patch fixes this by using unsigned longs. As unsigned
numbers follow the rules of modular arithmetic, the computations are
correct event after the millis() rollover in ~ 49.7 days.

Fixes issue #3: Improper use of signed integers.