### PR TITLE
Add virtual destructor to thread.h to prevent undefined behavior on destruction.

### DIFF
--- a/Thread.h
+++ b/Thread.h
@@ -69,6 +69,7 @@ public:
 	#endif
 
 	Thread(void (*callback)(void) = NULL, unsigned long _interval = 0);
+	virtual ~Thread() {};
 
 	// Set the desired interval for calls, and update _cached_next_run
 	virtual void setInterval(unsigned long _interval);


### PR DESCRIPTION
According to the documentation of ArduinoThread one should be able to inherit from the Thread class: 

"Inheriting from Thread or even ThreadController is always a good idea. For example, I always create base classes of sensors that extends Thread, so that I can "register" the sensors inside a ThreadController, and forget about really reading sensors, just getting theirs values within my main code. Checkout SensorThread example."

When doing this in Eclipse I get an error like "Class 'XXX' has virtual method 'run' but non-virtual destructor"

according to this:

https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#discussion-make-base-class-destructors-public-and-virtual-or-protected-and-nonvirtual

a base class should define a public virtual destructor otherwise destruction via a pointer to a base class would lead to undefined behavior (and a possible memory leak as the inherited destructor isn't guaranteed to be called).

...and a disclaimer: I'm originally a Java guy and has just recently started to learn C++. I might have gotten everything completely wrong :)