### PR TITLE
fix bug in example CustomTimedThread when overriding shouldRun

### DIFF
--- a/examples/CustomTimedThread/CustomTimedThread.ino
+++ b/examples/CustomTimedThread/CustomTimedThread.ino
@@ -113,7 +113,7 @@ public:
 		"Old" default Thread method 'shouldRun' return if
 		it should run.
 	*/
-	bool shouldRun(long time){
+	bool shouldRun(unsigned long time){
 		// Override enabled on thread when pin goes LOW.
 		if(digitalRead(pin) == LOW){
 			enabled = true;


### PR DESCRIPTION
Hi @ivanseidel 

I've tried adapting the example CustomTimedThread, but the shouldRun function was never executed. Compared to Thread.h it should be an "unsigned long".

Cheers

Mitosch