### PR TITLE
Use uintptr_t type for ThreadID

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ interrupts(); // This will enable the interrupts egain. DO NOT FORGET!
   (Basically,the logic is: (reached time AND is enabled?).
 - `void Thread::onRun(<function>)` - The target callback function to be called.
 - `void Thread::run()` - Runs the thread (executes the callback function).
-- `int Thread::ThreadID` - Theoretically, it's the memory address. It's unique, and can
+- `uintptr_t Thread::ThreadID` - Theoretically, it's the memory address. It's unique, and can
   be used to compare if two threads are identical.
 - `int Thread::ThreadName` - A human-readable thread name. 
     Default is "Thread ThreadID", eg.: "Thread 141515". 

--- a/Thread.cpp
+++ b/Thread.cpp
@@ -6,7 +6,7 @@ Thread::Thread(void (*callback)(void), unsigned long _interval){
 	_cached_next_run = 0;
 	last_run = millis();
 
-	ThreadID = (int)this;
+	ThreadID = reinterpret_cast<uintptr_t>(this);
 	#ifdef USE_THREAD_NAMES
 		ThreadName = "Thread ";
 		ThreadName = ThreadName + ThreadID;

--- a/Thread.h
+++ b/Thread.h
@@ -61,7 +61,7 @@ public:
 	bool enabled;
 
 	// ID of the Thread (initialized from memory adr.)
-	int ThreadID;
+	uintptr_t ThreadID;
 
 	#ifdef USE_THREAD_NAMES
 		// Thread Name (used for better UI).

--- a/ThreadController.cpp
+++ b/ThreadController.cpp
@@ -63,7 +63,7 @@ bool ThreadController::add(Thread* _thread){
 	return false;
 }
 
-void ThreadController::remove(int id){
+void ThreadController::remove(uintptr_t id){
 	// Find Threads with the id, and removes
 	for(int i = 0; i < MAX_THREADS; i++){
 		if(thread[i]->ThreadID == id){

--- a/ThreadController.h
+++ b/ThreadController.h
@@ -36,7 +36,7 @@ public:
 	bool add(Thread* _thread);
 
 	// remove the thread (given the Thread* or ThreadID)
-	void remove(int _id);
+	void remove(uintptr_t _id);
 	void remove(Thread* _thread);
 
 	// Removes all threads


### PR DESCRIPTION
For Arduino target code there is no difference between int and pointer sizes but it matters when compiling the code for unit test on a 64bit linux host computer:

```shell
.../arduino/sketchbook/libraries/ArduinoThread/Thread.cpp: In constructor ‘Thread::Thread(void (*)(), long unsigned int)’:
.../arduino/sketchbook/libraries/ArduinoThread/Thread.cpp:9:18: error: cast from ‘Thread*’ to ‘int’ loses precision [-fpermissive]
  ThreadID = (int)this;
                  ^~~~
```